### PR TITLE
Turn down concurrency to fix worker out of memory errors on Heroku

### DIFF
--- a/run.py
+++ b/run.py
@@ -54,7 +54,7 @@ def runserver(reload):
 
 @app.cli.command('celeryd')
 def celeryd():
-    celery_args = ['celery', 'worker', '-l', 'info', '-E']
+    celery_args = ['celery', 'worker', '-l', 'info', '-E', '-c', '4']
     with app.app_context():
         return celery_main(celery_args)
 


### PR DESCRIPTION
![2018-06-19 16_21_30- papertrail _platform errors_ alert_ 1269 matches at 2018-06-18 05_08 - scott](https://user-images.githubusercontent.com/137162/41627271-d95baec8-73dc-11e8-918d-594777c38329.png)
